### PR TITLE
Support libpurple 2.13

### DIFF
--- a/src/handlers/entrypoints.rs
+++ b/src/handlers/entrypoints.rs
@@ -43,6 +43,7 @@ pub extern "C" fn login<P: traits::LoginHandler>(account_ptr: *mut purple_sys::P
     };
 }
 
+#[cfg(libpurple2_14)]
 pub extern "C" fn get_cb_alias<P: traits::GetChatBuddyAlias>(
     connection_ptr: *mut purple_sys::PurpleConnection,
     id: i32,

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -206,5 +206,9 @@ impl_extra_handler_builder! {
     get_chat_name => GetChatNameHandler
     send_im => SendIMHandler
     chat_send => ChatSendHandler
+}
+
+#[cfg(libpurple2_14)]
+impl_extra_handler_builder! {
     get_cb_alias => GetChatBuddyAlias
 }


### PR DESCRIPTION
`get_cb_alias` was introduced in 2.14 and referencing it directly in this macro breaks compilation against libpurple-2.13, as found in Debian Buster.

https://docs.pidgin.im/pidgin/2.x.y/struct__PurplePluginProtocolInfo.html#ad43cef005f1634b0d170cc2972c69550

I don't think this is the best way to solve the problem, but I'm not familiar enough with macros to get the `libpurple2_14` config to apply inside of `impl_extra_handler_builder!`

Perhaps other bits of code should be conditional on the cfg as well? For me, this is sufficient to get it to compile against purple 2.13, but I'm not too clear on the implications of leaving around the code that *would* be used by the GetChatBuddyAlias declaration, e.g., in handlers.