### PR TITLE
purple: Add a way to specify and receive the account password

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -41,6 +41,15 @@ impl Account {
         }
     }
 
+    pub fn get_password(&self) -> Option<Cow<str>> {
+        let password_ptr = unsafe { purple_sys::purple_account_get_password(self.0) };
+        if password_ptr.is_null() {
+            None
+        } else {
+            Some(unsafe { CStr::from_ptr(password_ptr) }.to_string_lossy())
+        }
+    }
+
     pub fn is_disconnected(&self) -> bool {
         let is_disconnected = unsafe { purple_sys::purple_account_is_disconnected(self.0) };
         is_disconnected != 0

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -99,6 +99,14 @@ impl<P> RegisterContext<P> {
             masked: false,
         })
     }
+
+    pub fn with_password(mut self) -> Self {
+        self.extra_info.options = purple_sys::PurpleProtocolOptions(
+            self.extra_info.options.0 & !purple_sys::PurpleProtocolOptions::OPT_PROTO_NO_PASSWORD.0,
+        );
+
+        self
+    }
 }
 
 pub struct PrplPluginLoader<P: PrplPlugin>(*mut purple_sys::PurplePlugin, PhantomData<P>);


### PR DESCRIPTION
libpurple has a default "password" option. The purple-sys crate turns it off by default, but some providers do need to take a password.

This approach to removing the `OPT_PROTO_NO_PASSWORD` flag is a bit unclean - we duplicate knowledge in purple_sys - but the `BitNot` trait isn't implemented for the struct outputted by bindgen-rust, so there are no great options without also changing purple_sys.

Signed-off-by: Nick Thomas <me@ur.gs>